### PR TITLE
Add Tides Service and Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesController.java
@@ -2,8 +2,43 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.TidesQueryService;
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Tide Information from NOAA https://api.tidesandcurrents.noaa.gov/api/prod/")
+@Slf4j
 @RestController
+@RequestMapping("/api/tides")
 public class TidesController {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    TidesQueryService tidesQueryService;
+
+    @Operation(summary = "Get water level for date range, in local time.", description = "For station id, see: https://tidesandcurrents.noaa.gov/tide_predictions.html?gid=1393")
+    @GetMapping("/get")
+    public ResponseEntity<String> getTides(
+        @Parameter(name="beginDate", description="beginDate in format yyyymmdd") @RequestParam String beginDate,
+        @Parameter(name="endDate", description="endDate in format yyyymmdd") @RequestParam String endDate,
+        @Parameter(name="station", description="station", example="9411340 for Santa Barbara") @RequestParam String station
+    ) throws JsonProcessingException {
+        log.info("getTides: beginDate={} endDate={} station={}", beginDate, endDate, station);
+        String result = tidesQueryService.getJSON(beginDate, endDate, station);
+        return ResponseEntity.ok().body(result);
+    }
 
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -25,7 +25,7 @@ public class TidesQueryService {
     }
 
     // Documentation for endpoint is at: https://api.tidesandcurrents.noaa.gov/api/prod/
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date={beginDate}&end_date={endDate}&station={station}&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json";
 
     public String getJSON(String beginDate, String endDate, String station) throws HttpClientErrorException {
         return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryService.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
-
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -9,11 +10,15 @@ import org.springframework.web.client.RestTemplate;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
-
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
-
+@Slf4j
 @Service
 public class TidesQueryService {
 
@@ -28,6 +33,17 @@ public class TidesQueryService {
     public static final String ENDPOINT = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?application=ucsb-cs156&begin_date={beginDate}&end_date={endDate}&station={station}&product=predictions&datum=mllw&units=english&time_zone=lst_ldt&interval=hilo&format=json";
 
     public String getJSON(String beginDate, String endDate, String station) throws HttpClientErrorException {
-        return "";
+        log.info("beginDate={}, endDate={}, station={}", beginDate, endDate, station);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> uriVariables = Map.of("beginDate", beginDate, "endDate", endDate, "station", station);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/TidesControllerTests.java
@@ -1,0 +1,49 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.TidesQueryService;
+
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(value = TidesController.class)
+public class TidesControllerTests {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    TidesQueryService mockTidesQueryService;
+
+    @Test
+    public void test_getTides() throws Exception {
+  
+        String fakeJsonResult="{ \"fake\" : \"result\" }";
+        String beginDate = "20220716";
+        String endDate = "20220717";
+        String station = "9411340";
+        when(mockTidesQueryService.getJSON(eq(beginDate),eq(endDate),eq(station))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/tides/get?beginDate=%s&endDate=%s&station=%s",beginDate,endDate,station);
+
+        MvcResult response = mockMvc
+            .perform( get(url).contentType("application/json"))
+            .andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+  }
+    
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/TidesQueryServiceTests.java
@@ -1,0 +1,44 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(TidesQueryService.class)
+public class TidesQueryServiceTests {
+    
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private TidesQueryService tidesQueryService;
+
+    @Test
+    public void test_getJSON() {
+            
+        String beginDate = "20220716";
+        String endDate = "20220717";
+        String station = "9411340";
+        String expectedURL = TidesQueryService.ENDPOINT.replace("{beginDate}", beginDate)
+                .replace("{endDate}", endDate).replace("{station}", station);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = tidesQueryService.getJSON(beginDate, endDate, station);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/tides/get` that can be used to get information about the tides of a particular station.
Dev Link: http://team01-jasontnguyen-dev.dokku-05.cs.ucsb.edu

Close #13 
