### PR TITLE
Add Joke Controller and Test

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -2,7 +2,40 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Jokes from https://v2.jokeapi.dev/")
 @RestController
+@RequestMapping("/api/jokes")
 public class JokeController {
-    
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    JokeQueryService jokeQueryService;
+
+    @Operation(summary = "Get an english language joke in safe mode (non-offensive)")
+    @GetMapping("/get")
+    public ResponseEntity<String> getJokes(
+	@Parameter(name="category", example="All")@RequestParam String category, 
+	@Parameter(name="numJokes", example="1")@RequestParam String numJokes 
+    ) throws JsonProcessingException {
+        String result = jokeQueryService.getJSON(category, numJokes);
+        return ResponseEntity.ok().body(result);
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -15,7 +15,7 @@ public class JokeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/{category}?amount={numJokes}";
 
     public String getJSON(String category, int numJokes) throws HttpClientErrorException {
         return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -1,9 +1,23 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.web.client.RestTemplate;
+
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
+
 
 
 @Service
@@ -17,7 +31,18 @@ public class JokeQueryService {
 
     public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/{category}?amount={numJokes}";
 
-    public String getJSON(String category, int numJokes) throws HttpClientErrorException {
-        return "";
+    public String getJSON(String category, String numJokes) throws HttpClientErrorException {
+
+	HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+	
+	Map<String, String> uriVariables = Map.of("category", category, "numJokes", numJokes);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+	ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+	return re.getBody();
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
@@ -1,0 +1,62 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+@WebMvcTest(value = JokeController.class)
+public class JokeControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  JokeQueryService mockJokeQueryService;
+
+
+  @Test
+  public void test_getJokes() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String category = "All";
+    String numJokes = "1";
+    when(mockJokeQueryService.getJSON(eq(category),eq(numJokes))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/jokes/get?category=%s&numJokes=%s",category,numJokes);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}
+
+
+

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
@@ -1,0 +1,43 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(JokeQueryService.class)
+public class JokeQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private JokeQueryService jokeQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String category = "All";
+	String numJokes = "1";
+        String expectedURL = JokeQueryService.ENDPOINT.replace("{category}", category).replace("{numJokes}", numJokes);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = jokeQueryService.getJSON(category, numJokes);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/joke/get` that can be used to get information jokes.
Dev deployment at: http://team01-winstonwang-dev.dokku-05.cs.ucsb.edu/swagger-ui/index.html

Closes #7 